### PR TITLE
Update oauth base url to login.microsoftonline.com

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -33,7 +33,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function getAuthUrl($state)
     {
         return $this->buildAuthUrlFromBase(
-            'https://login.windows.net/common/oauth2/authorize', $state
+            'https://login.microsoftonline.com/common/oauth2/authorize', $state
         );
     }
 
@@ -42,7 +42,7 @@ class Provider extends AbstractProvider implements ProviderInterface
      */
     protected function getTokenUrl()
     {
-        return 'https://login.windows.net/common/oauth2/token';
+        return 'https://login.microsoftonline.com/common/oauth2/token';
     }
 
     public function getAccessToken($code)


### PR DESCRIPTION
Authorize url has been changed recently to **login.microsoftonline.com**. **login.windows.net** still works but results in an extra 301 redirect.

See:
https://msdn.microsoft.com/en-nz/library/azure/dn645542.aspx#Anchor_2
