### PR TITLE
Add support for optional post_logout_redirect_uri

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -37,16 +37,26 @@ class Provider extends AbstractProvider
     }
 
     /**
-     * Return the logout endpoint with post_logout_redirect_uri query parameter.
+     * Return the logout endpoint with an optional post_logout_redirect_uri query parameter.
      *
-     * @param  string  $redirectUri
-     * @return string
+     * @param string|null $redirectUri The URI to redirect to after logout, if provided.
+     *                                 If not provided, no post_logout_redirect_uri parameter will be included.
+     *
+     * @return string The logout endpoint URL.
      */
-    public function getLogoutUrl(string $redirectUri)
+    public function getLogoutUrl(?string $redirectUri = null)
     {
-        return $this->getBaseUrl()
-            .'/oauth2/logout?'
-            .http_build_query(['post_logout_redirect_uri' => $redirectUri], '', '&', $this->encodingType);
+        $queryParams = [];
+        if ($redirectUri !== null) {
+            $queryParams['post_logout_redirect_uri'] = $redirectUri;
+        }
+
+        $logoutUrl = $this->getBaseUrl() . '/oauth2/logout';
+        if (!empty($queryParams)) {
+            $logoutUrl .= '?' . http_build_query($queryParams, '', '&', $this->encodingType);
+        }
+
+        return $logoutUrl;
     }
 
     /**


### PR DESCRIPTION
# Support for optional post logout redirect uri

## Issue
Right now, the library doesn't support the case when you don't want to redirect the user after a succesful logout. I needed this case, and I think it makes sense to make it available through this provider.

## Solution
Set the $redirectUri as an optional parameter to keep it backward compatible. Post_logout_redirect_uri is meant to be optional also according to the OpenID (https://openid.net/specs/openid-connect-rpinitiated-1_0.html)