### PR TITLE
Add getAvatar() Method to User Class

### DIFF
--- a/User.php
+++ b/User.php
@@ -3,6 +3,7 @@
 namespace SocialiteProviders\Azure;
 
 use SocialiteProviders\Manager\OAuth2\User as oAuth2User;
+use Illuminate\Support\Facades\Http;
 
 class User extends oAuth2User
 {
@@ -38,5 +39,22 @@ class User extends oAuth2User
     public function getMail()
     {
         return $this->mail;
+    }
+
+    /**
+     * Get the avatar for the user.
+     *
+     * @return string
+     */
+    public function getAvatar(): ?string
+    {
+        $response = Http::withToken($this->token)
+            ->get('https://graph.microsoft.com/v1.0/me/photo/$value');
+
+        if ($response->successful()) {
+            return $response->body();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## ✨ Add `getAvatar()` Method to Microsoft Azure User Class

### Summary

This PR introduces a `getAvatar()` method to the `User` class in the Microsoft Azure provider. The method retrieves the authenticated user's profile photo using the Microsoft Graph API (`/me/photo/$value`) and returns the image binary.

### Why This Should Be in the Provider

- **Standardization**: Including this logic in the provider ensures consistent handling of avatar retrieval across all applications using this package. It avoids duplicating the same logic in every consuming app.
- **Cleaner Application Code**: Without this change, developers must manually implement Graph API calls and token handling in their apps. This PR encapsulates that logic where it belongs — in the provider.
- **Backward Compatible**: This is a non-breaking addition. It does not alter existing behavior and only adds a new method.
- **No Additional Configuration Required**: The method uses the existing access token and does not require any changes to scopes or provider setup.
- **Tested**: The implementation has been tested against multiple Azure AD tenants (work accounts) and returns the expected image data.

### Example Usage

```php
$user = Socialite::driver('azure')->user();
$avatar = $user->getAvatar(); // Returns image binary or null

### Notes
- The method returns the raw image binary. It is up to the consuming application to store or display it as needed.
- If the user has no profile photo or the request fails, null is returned.
